### PR TITLE
Match data size labels to calculations

### DIFF
--- a/Unverum/StringConverters.cs
+++ b/Unverum/StringConverters.cs
@@ -10,7 +10,7 @@ namespace Unverum
     {
         // Load all suffixes in an array  
         static readonly string[] suffixes =
-        { " Bytes", " KB", " MB", " GB", " TB", " PB" };
+        { " Bytes", " KiB", " MiB", " GiB", " TiB", " PiB" };
         public static string FormatSize(long bytes)
         {
             int counter = 0;


### PR DESCRIPTION
Mismatch between data size labels and the calculations. Labels are in decimal, calculations are in binary. Easiest way to match them is to switch the labels.