### PR TITLE
Added SortAlphabetical feature for mods list

### DIFF
--- a/Unverum/UI/MainWindow.xaml
+++ b/Unverum/UI/MainWindow.xaml
@@ -441,16 +441,16 @@
                                         <Setter Property="FontWeight" Value="SemiBold"/>
                                     </Style>
                                 </DataGrid.Resources>
-								<DataGrid.ColumnHeaderStyle>
-									<Style TargetType="DataGridColumnHeader">
-										<Setter Property="Background" Value="#303030" />
-										<Setter Property="Foreground" Value="#f2f2f2"/>
-										<Setter Property="Height" Value="17"/>
-										<Setter Property="FontSize" Value="12"/>
-										<Setter Property="FontWeight" Value="SemiBold"/>
-										<EventSetter Event="Click" Handler="SortAlphabeticallyAndGroupEnabled_Click"/>
-									</Style>
-								</DataGrid.ColumnHeaderStyle>
+				<DataGrid.ColumnHeaderStyle>
+					<Style TargetType="DataGridColumnHeader">
+						<Setter Property="Background" Value="#303030" />
+						<Setter Property="Foreground" Value="#f2f2f2"/>
+						<Setter Property="Height" Value="17"/>
+						<Setter Property="FontSize" Value="12"/>
+						<Setter Property="FontWeight" Value="SemiBold"/>
+						<EventSetter Event="Click" Handler="SortAlphabeticallyAndGroupEnabled_Click"/>
+					</Style>
+				</DataGrid.ColumnHeaderStyle>
                                 <DataGrid.ContextMenu>
                                     <ContextMenu>
                                         <MenuItem Header="Fetch Metadata" IsCheckable="False" Click="FetchItem_Click"/>

--- a/Unverum/UI/MainWindow.xaml
+++ b/Unverum/UI/MainWindow.xaml
@@ -441,6 +441,16 @@
                                         <Setter Property="FontWeight" Value="SemiBold"/>
                                     </Style>
                                 </DataGrid.Resources>
+								<DataGrid.ColumnHeaderStyle>
+									<Style TargetType="DataGridColumnHeader">
+										<Setter Property="Background" Value="#303030" />
+										<Setter Property="Foreground" Value="#f2f2f2"/>
+										<Setter Property="Height" Value="17"/>
+										<Setter Property="FontSize" Value="12"/>
+										<Setter Property="FontWeight" Value="SemiBold"/>
+										<EventSetter Event="Click" Handler="SortAlphabeticallyAndGroupEnabled_Click"/>
+									</Style>
+								</DataGrid.ColumnHeaderStyle>
                                 <DataGrid.ContextMenu>
                                     <ContextMenu>
                                         <MenuItem Header="Fetch Metadata" IsCheckable="False" Click="FetchItem_Click"/>

--- a/Unverum/UI/MainWindow.xaml.cs
+++ b/Unverum/UI/MainWindow.xaml.cs
@@ -1469,5 +1469,19 @@ namespace Unverum
                 handle = false;
             }
         }
+
+        private void SortAlphabeticallyAndGroupEnabled_Click(object sender, RoutedEventArgs e)
+        {
+            DataGridColumnHeader colHeader = sender as DataGridColumnHeader;
+            if(colHeader != null && colHeader.Column.Header.Equals("Name"))
+            {
+                ModGrid.Items.SortDescriptions.Clear();
+                ModGrid.Items.SortDescriptions.Add(new SortDescription("enabled", ListSortDirection.Descending));
+                ModGrid.Items.SortDescriptions.Add(new SortDescription("name", ListSortDirection.Ascending));
+                Global.logger.WriteLine("Sorted!", LoggerType.Info);
+                ModGrid.Items.Refresh();
+            }
+            e.Handled = true;
+        }
     }
 }


### PR DESCRIPTION
Clicking the the name header will now sort the mods list alphabetically. The mods will still be grouped by enabled or disabled with enabled being at the top. I added an event click for the DataGridColumnHeaders in ModGrid to implement the feature, and I constrained it so that the event only happens if Name header is clicked. 