### PR TITLE
Add virtual build

### DIFF
--- a/Unverum/Logger.cs
+++ b/Unverum/Logger.cs
@@ -24,7 +24,7 @@ namespace Unverum
             outputWindow = textBox;
         }
 
-        public void WriteLine(string text, LoggerType type)
+        public void Write(string text, LoggerType type, bool meta = false)
         {
             string color = "#F2F2F2";
             string header = "";
@@ -46,8 +46,13 @@ namespace Unverum
             // Call on UI thread
             Application.Current.Dispatcher.Invoke(() =>
             {
-                outputWindow.AppendText($"[{DateTime.Now}] [{header}] {text}\n", color);
+                outputWindow.AppendText(meta ? $"[{DateTime.Now}] [{header}] {text}" : $"{text}", color);
             });
+        }
+
+        public void WriteLine(string text, LoggerType type)
+        {
+            Write($"{text}\n", type, true);
         }
     }
 

--- a/Unverum/ModContent.cs
+++ b/Unverum/ModContent.cs
@@ -1,0 +1,129 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Unverum;
+
+public class ModFileMeta
+{
+    private readonly Mod mod;
+
+    private readonly List<InstallableModObject> objects;
+
+
+    public ModFileMeta(Mod mod)
+    {
+        this.mod = mod;
+        var modPath =
+            $@"{Global.assemblyLocation}{Global.s}Mods{Global.s}{Global.config.CurrentGame}{Global.s}{mod.name}";
+        objects = Scan(modPath);
+    }
+
+    private static List<InstallableModObject> Scan(string path)
+    {
+        var files = new List<InstallableModObject>();
+        files.AddRange(Directory.GetFiles(path, "*.*", SearchOption.AllDirectories)
+            .Where(file => Path.GetExtension(file).Equals(".pak", StringComparison.InvariantCultureIgnoreCase))
+            .Select(pak => new Pak(path, pak)));
+
+        // files.AddRange(Directory.GetDirectories(path, "*CoreMods", SearchOption.AllDirectories)
+        //     .SelectMany(dirs => Directory.GetFiles(dirs, "*", SearchOption.AllDirectories))
+        //     .Select(mod => new CoreMods(mod)));
+        //
+        // files.AddRange(Directory.GetDirectories(path, "*LogicMods", SearchOption.AllDirectories)
+        //     .SelectMany(dirs => Directory.GetFiles(dirs, "*", SearchOption.AllDirectories))
+        //     .Select(mod => new LogicMods(mod)));
+
+
+        return files;
+    }
+
+    public Dictionary<string, string> GetFiles(InstallContext ctx)
+    {
+        var enabledPak = mod.paks.Where(pair => pair.Value)
+            .Select(pair => pair.Key)
+            // FIXME: update Mod pak names
+            // .Select(path =>
+            // {
+            //     return Path.GetRelativePath(modRoot, path);
+            // })
+            .Select(Path.GetFullPath)
+            .ToList();
+
+        return objects
+            .Where(o => o switch
+            {
+                Pak pak => enabledPak.Contains(pak.PakFullPath()),
+                _ => true
+            })
+            .SelectMany(o => o.GetFiles(ctx))
+            .ToDictionary(pair => pair.Key, pair => pair.Value);
+    }
+}
+
+public interface InstallableModObject
+{
+    public Dictionary<string, string> GetFiles(InstallContext ctx);
+}
+
+public class InstallContext
+{
+    public string? SigPath { get; }
+    public string? SplashPath { get; }
+    public string? MoviesPath { get; }
+    public string? SoundsPath { get; }
+
+    public InstallContext(string? sigPath, string? splashPath, string? moviesPath, string? soundsPath)
+    {
+        SigPath = sigPath;
+        SplashPath = splashPath;
+        MoviesPath = moviesPath;
+        SoundsPath = soundsPath;
+    }
+}
+
+class Pak : InstallableModObject
+{
+    private readonly string pakPath;
+    private readonly string modRoot;
+    private readonly List<string> files;
+
+    private readonly bool hasSig;
+
+    public Pak(string modRoot, string pakPath)
+    {
+        this.modRoot = modRoot;
+        this.pakPath = Path.GetRelativePath(modRoot, pakPath);
+        files = new List<string> { this.pakPath };
+
+        var sig = Path.ChangeExtension(this.pakPath, ".sig");
+        hasSig = File.Exists(Path.Join(this.modRoot, sig));
+        if (hasSig) files.Add(sig);
+
+        var utoc = Path.ChangeExtension(this.pakPath, ".utoc");
+        var ucas = Path.ChangeExtension(this.pakPath, ".ucas");
+        if (File.Exists(Path.Join(this.modRoot, utoc)) &&
+            File.Exists(Path.Join(this.modRoot, ucas)))
+        {
+            files.AddRange(new[] { utoc, ucas });
+        }
+    }
+
+    public Dictionary<string, string> GetFiles(InstallContext ctx)
+    {
+        var outputs = files.ToDictionary(s => Path.Join(modRoot, s), s => s);
+
+        if (!hasSig && ctx.SigPath != null)
+            outputs.Add(ctx.SigPath, Path.ChangeExtension(PakFullPath(), ".sig"));
+
+        return outputs;
+    }
+
+    public string PakFullPath()
+    {
+        return Path.GetFullPath(Path.Join(modRoot, pakPath));
+    }
+}

--- a/Unverum/UI/MainWindow.xaml.cs
+++ b/Unverum/UI/MainWindow.xaml.cs
@@ -414,7 +414,7 @@ namespace Unverum
                 Refresh();
                 Directory.CreateDirectory(Global.config.Configs[Global.config.CurrentGame].ModsFolder);
                 Global.logger.WriteLine($"Building loadout for {Global.config.CurrentGame}", LoggerType.Info);
-                if (!await Build(Global.config.Configs[Global.config.CurrentGame].ModsFolder))
+                if (!await BuildDiff(Global.config.Configs[Global.config.CurrentGame].ModsFolder))
                 {
                     Global.logger.WriteLine($"Failed to build loadout, not building and launching", LoggerType.Error);
                     ModGrid.IsEnabled = true;
@@ -690,6 +690,100 @@ namespace Unverum
                         }
                     }
                 }
+        }
+
+        private async Task<bool> BuildDiff(string path)
+        {
+            return await Task.Run(() =>
+            {
+                string sig = Directory.GetFiles(Path.GetDirectoryName(path), "*.sig", SearchOption.TopDirectoryOnly)
+                    .FirstOrDefault();
+
+                var ctx = new InstallContext(sig, null, null, null);
+
+                var modFiles = Global.config.Configs[Global.config.CurrentGame].ModList
+                    .Where(x => x.enabled)
+                    .Select(m => new ModFileMeta(m))
+                    .Reverse()
+                    .ToList();
+
+
+                var fmt = $"D{modFiles.Count().ToString().Length}";
+
+                var wantSrcDst = modFiles
+                    .Select(m => m.GetFiles(ctx))
+                    .SelectMany((files, i) => 
+                        files.ToImmutableDictionary(
+                            mapping => mapping.Key, 
+                            mapping => Path.Join(path, i.ToString(fmt), mapping.Value))
+                    ).ToImmutableDictionary(pair => pair.Key, pair => pair.Value);
+
+                var wantFiles = wantSrcDst.Select(pair => pair.Value).ToHashSet();
+
+                if (wantSrcDst.Count != wantFiles.Count)
+                {
+                    var dupes = wantSrcDst.GroupBy(pair => pair.Value)
+                        .Where(g => g.Count() > 1)
+                        .SelectMany(g => g.Key)
+                        .ToList();
+                    Global.logger.WriteLine($"Duplicate Files found in mods {string.Join(",", dupes)}", LoggerType.Warning);
+                }
+
+
+                var tmp = Path.Join(path, "mod_data.tmp");
+                try
+                {
+                    File.Delete(tmp);
+                }
+                catch (Exception e)
+                {
+                    Global.logger.WriteLine($"Failed delete tmp file {tmp}: {e.Message}", LoggerType.Error);
+                    return false;
+                }
+
+                var existingFiles = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories).ToHashSet();
+
+                if (existingFiles.SetEquals(wantFiles))
+                {
+                    Global.logger.WriteLine($"~mods up-to-date.", LoggerType.Info);
+                    return true;
+                }
+
+                try
+                {
+                    var toDelete = existingFiles.Except(wantFiles).ToList();
+                    var toCopy = wantFiles.Except(existingFiles).ToList();
+
+                    toDelete.ForEach(s =>
+                    {
+                        Global.logger.WriteLine($"Deleting {s}", LoggerType.Info);
+                        File.Delete(s);
+                    });
+
+                    wantSrcDst.Where(pair => toCopy.Contains(pair.Value))
+                        .ToList()
+                        .ForEach(srcDst =>
+                        {
+                            Global.logger.Write($"Writing {srcDst.Value}..", LoggerType.Info, true);
+                            Directory.CreateDirectory(Path.GetDirectoryName(srcDst.Value) ?? throw new InvalidOperationException());
+                            
+                            // Copy to tmp first to ensure file at srcDst.Value is always complete
+                            File.Copy(srcDst.Key, tmp, true);
+                            File.Move(tmp, srcDst.Value, true);
+
+                            Global.logger.Write("Done\n", LoggerType.Info);
+                        });
+                }
+                catch (Exception e)
+                {
+                    Global.logger.WriteLine($"Failed to build ~mods {e.Message}", LoggerType.Error);
+                    return false;
+                }
+
+                // TODO: delete empty dirs
+
+                return true;
+            });
         }
 
         private async Task<bool> Build(string path)


### PR DESCRIPTION
Draft for allowing incremental mod updates. i.e. `~mods` is not fully rebuild every launch. If the config is up-to-date, it can launch the game immediately.

This is achieved by doing the following steps in `BuildDiff`:
- scan user provided mods based on for different file types `ModFileMeta#Scan`
- generates a list of files desired files based on game context `ModFileMeta#GetFiles`
- compare desired vs existing
- apply the update

LMK what do you think about this approach.