### PR TITLE
Allow Text Patching for a specific language

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/Unverum/bin/Debug/net6.0-windows/Unverum.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/Unverum",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Unverum.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/Unverum.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary;ForceNoAlign"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/Unverum.sln"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ As of v1.2.0, Unverum now supports modularly patching specific parts of REDAsset
 An example of how it's setup would be:
 ```
 {
+  "language": "FRA",
   "Entries": [
     {
       "header": "CHARA_NAME_L_HTN",
@@ -105,6 +106,8 @@ This example replaces each instance of Hit with Pepsiman in the game DBFZ.
 You can put as many entries as you want.  The headers can be found in the hex of REDAsset.uexp which are followed by the text that goes with it.  You would want to put the header of the part you would want to replace.  The text property is what you would want to replace the text that goes with the header specified.
 
 Note that for each game update, Unverum would have to update the base files used to match the current version of the game.  If you're tech savvy enough, you can manually replace the files found under the Resources folder if I take too long.
+
+With this version of Unverum, you can patch the entries of the language you want to change. If you have edited lines from the French version, just add the "language" key with the "FRA" value. Unverum will then replace all lines as usual but for the French language.
 
 ## FAQ
 ### Are music/splash/movie mods supported?

--- a/Unverum/Global.cs
+++ b/Unverum/Global.cs
@@ -19,6 +19,7 @@ namespace Unverum
         public static List<string> games;
         public static ObservableCollection<String> LoadoutItems;
         public static ObservableCollection<Mod> ModList;
+        public static string loc = "";
         public static void UpdateConfig()
         {
             config.Configs[config.CurrentGame].Loadouts[config.Configs[config.CurrentGame].CurrentLoadout] = ModList;

--- a/Unverum/ModLoader.cs
+++ b/Unverum/ModLoader.cs
@@ -391,12 +391,12 @@ namespace Unverum
                             {
                                 if (missing)
                                     continue;
-                                var pakName = Global.config.CurrentGame.Equals("DNF Duel", StringComparison.InvariantCultureIgnoreCase) ? "RED-WindowsNoEditor.pak" : "pakchunk0-WindowsNoEditor.pak";
+                                var pakName = Global.config.CurrentGame.Equals("DNF Duel", StringComparison.InvariantCultureIgnoreCase) ? "RED-WindowsNoEditor.pak" : "pakchunk1-WindowsNoEditor.pak";
                                 var text = File.ReadAllText(file);
 
                                 if (!set_localization(text))
                                 {
-                                    continue;
+                                    // continue;
                                 }
                                 if (entries == null && TextPatcher.ExtractBaseFiles(pakName, $"RED/Content/Localization/{Global.loc}/REDGame",
                                         $"RED{Global.s}Content{Global.s}Localization{Global.s}{Global.loc}{Global.s}REDGame.uexp"))
@@ -610,18 +610,13 @@ namespace Unverum
                     Global.logger.WriteLine($"Language modification was set on {Global.loc}, {loc} will be ignored", LoggerType.Warning);
                     return false;
                 }
-                var testPath = $"{Global.assemblyLocation}{Global.s}Resources{Global.s}{Global.config.CurrentGame}{Global.s}RED{Global.s}Content{Global.s}Localization{Global.s}{loc}{Global.s}REDGame.uasset";
-                if (!File.Exists(testPath))
-                {
-                    Global.logger.WriteLine($"No folder corresponding with {loc}, Text Patching won't be applied for this file.", LoggerType.Error);
-                    return false;
-                }
                 Global.loc = loc;
                 Global.logger.WriteLine($"'language' key found with {Global.loc} value for Text Patching", LoggerType.Info);
             }
             else
             {
-                Global.logger.WriteLine($"No 'language' key found. Default language set to INT", LoggerType.Info);
+                Global.loc = "INT";
+                Global.logger.WriteLine($"No 'language' key found. Default language set to {Global.loc}", LoggerType.Error);
             }
             return true;
         }

--- a/Unverum/ModLoader.cs
+++ b/Unverum/ModLoader.cs
@@ -394,10 +394,8 @@ namespace Unverum
                                 var pakName = Global.config.CurrentGame.Equals("DNF Duel", StringComparison.InvariantCultureIgnoreCase) ? "RED-WindowsNoEditor.pak" : "pakchunk1-WindowsNoEditor.pak";
                                 var text = File.ReadAllText(file);
 
-                                if (!set_localization(text))
-                                {
-                                    // continue;
-                                }
+                                set_localization(text);
+
                                 if (entries == null && TextPatcher.ExtractBaseFiles(pakName, $"RED/Content/Localization/{Global.loc}/REDGame",
                                         $"RED{Global.s}Content{Global.s}Localization{Global.s}{Global.loc}{Global.s}REDGame.uexp"))
                                     entries = TextPatcher.GetEntries();

--- a/Unverum/TextPatcher.cs
+++ b/Unverum/TextPatcher.cs
@@ -24,7 +24,7 @@ namespace Unverum
         public static bool ExtractBaseFiles(string pakName, string filter, string extractedPath)
         {
             var outputFolder = $"{Global.assemblyLocation}{Global.s}Resources{Global.s}{Global.config.CurrentGame}";
-            var umodel = $"{Global.assemblyLocation}{Global.s}Dependencies{Global.s}umodel{Global.s}umodel_64.exe"; 
+            var umodel = $"{Global.assemblyLocation}{Global.s}Dependencies{Global.s}umodel{Global.s}umodel_64.exe";
             var quickbms = $"{Global.assemblyLocation}{Global.s}Dependencies{Global.s}quickbms{Global.s}quickbms_4gb_files.exe";
             var ue4bms = $"{Global.assemblyLocation}{Global.s}Dependencies{Global.s}quickbms{Global.s}unreal_tournament_4.bms";
             var resourcesPath = $"{outputFolder}{Global.s}{extractedPath}";
@@ -35,7 +35,7 @@ namespace Unverum
                 Global.logger.WriteLine($"Missing dependencies, text patching will not work (Try redownloading)", LoggerType.Error);
                 return false;
             }
-            var pak = $"{Path.GetDirectoryName(Global.config.Configs[Global.config.CurrentGame].ModsFolder)}{Global.s}{pakName}";;
+            var pak = $"{Path.GetDirectoryName(Global.config.Configs[Global.config.CurrentGame].ModsFolder)}{Global.s}{pakName}"; ;
             if (!File.Exists(pak))
             {
                 Global.logger.WriteLine($"Couldn't find {pak} to extract text files from, text patching will not work", LoggerType.Error);
@@ -190,6 +190,7 @@ namespace Unverum
             var outputUexp = $"{Global.assemblyLocation}{Global.s}Dependencies{Global.s}u4pak{Global.s}RED{Global.s}Content{Global.s}Localization{Global.s}INT{Global.s}REDGame.uexp";
             var outputUasset = $"{Global.assemblyLocation}{Global.s}Dependencies{Global.s}u4pak{Global.s}RED{Global.s}Content{Global.s}Localization{Global.s}INT{Global.s}REDGame.uasset";
             var bytes = File.ReadAllBytes(inputUexp).ToList();
+            Global.logger.WriteLine($"Test", LoggerType.Info);
             bytes.RemoveRange(54, bytes.Count - 54);
             // Append dictionary of entries
             foreach (var key in dict.Keys)

--- a/Unverum/TextPatcher.cs
+++ b/Unverum/TextPatcher.cs
@@ -18,7 +18,6 @@ namespace Unverum
     {
         public string header { get; set; }
         public string text { get; set; }
-        public string loc { get; set; }
     }
     public static class TextPatcher
     {

--- a/Unverum/TextPatcher.cs
+++ b/Unverum/TextPatcher.cs
@@ -18,6 +18,7 @@ namespace Unverum
     {
         public string header { get; set; }
         public string text { get; set; }
+        public string loc { get; set; }
     }
     public static class TextPatcher
     {
@@ -140,7 +141,7 @@ namespace Unverum
         }
         public static Dictionary<string, Entry> GetEntries()
         {
-            var file = $"{Global.assemblyLocation}{Global.s}Resources{Global.s}{Global.config.CurrentGame}{Global.s}RED{Global.s}Content{Global.s}Localization{Global.s}INT{Global.s}REDGame.uexp";
+            var file = $"{Global.assemblyLocation}{Global.s}Resources{Global.s}{Global.config.CurrentGame}{Global.s}RED{Global.s}Content{Global.s}Localization{Global.s}{Global.loc}{Global.s}REDGame.uexp";
             if (!File.Exists(file) || !File.Exists(Path.ChangeExtension(file, ".uasset")))
                 return null;
             var bytes = File.ReadAllBytes(file);
@@ -148,6 +149,7 @@ namespace Unverum
             var allText = Encoding.Unicode.GetString(bytes[54..(bytes.Length - 4)]);
             // Split by the delimiter 0x0D0A
             var entries = allText.Split("\r\n");
+            Global.logger.WriteLine($"Successfully extracted base files for patching", LoggerType.Info);
             var counter = 0;
             var dict = new Dictionary<string, Entry>();
             // Convert array of strings to dictionary
@@ -185,12 +187,11 @@ namespace Unverum
             // Delete previous text files if they exist
             if (Directory.Exists($"{Global.assemblyLocation}{Global.s}Dependencies{Global.s}u4pak{Global.s}RED"))
                 Directory.Delete($"{Global.assemblyLocation}{Global.s}Dependencies{Global.s}u4pak{Global.s}RED", true);
-            var inputUexp = $"{Global.assemblyLocation}{Global.s}Resources{Global.s}{Global.config.CurrentGame}{Global.s}RED{Global.s}Content{Global.s}Localization{Global.s}INT{Global.s}REDGame.uexp";
-            var inputUasset = $"{Global.assemblyLocation}{Global.s}Resources{Global.s}{Global.config.CurrentGame}{Global.s}RED{Global.s}Content{Global.s}Localization{Global.s}INT{Global.s}REDGame.uasset";
-            var outputUexp = $"{Global.assemblyLocation}{Global.s}Dependencies{Global.s}u4pak{Global.s}RED{Global.s}Content{Global.s}Localization{Global.s}INT{Global.s}REDGame.uexp";
-            var outputUasset = $"{Global.assemblyLocation}{Global.s}Dependencies{Global.s}u4pak{Global.s}RED{Global.s}Content{Global.s}Localization{Global.s}INT{Global.s}REDGame.uasset";
+            var inputUexp = $"{Global.assemblyLocation}{Global.s}Resources{Global.s}{Global.config.CurrentGame}{Global.s}RED{Global.s}Content{Global.s}Localization{Global.s}{Global.loc}{Global.s}REDGame.uexp";
+            var inputUasset = $"{Global.assemblyLocation}{Global.s}Resources{Global.s}{Global.config.CurrentGame}{Global.s}RED{Global.s}Content{Global.s}Localization{Global.s}{Global.loc}{Global.s}REDGame.uasset";
+            var outputUexp = $"{Global.assemblyLocation}{Global.s}Dependencies{Global.s}u4pak{Global.s}RED{Global.s}Content{Global.s}Localization{Global.s}{Global.loc}{Global.s}REDGame.uexp";
+            var outputUasset = $"{Global.assemblyLocation}{Global.s}Dependencies{Global.s}u4pak{Global.s}RED{Global.s}Content{Global.s}Localization{Global.s}{Global.loc}{Global.s}REDGame.uasset";
             var bytes = File.ReadAllBytes(inputUexp).ToList();
-            Global.logger.WriteLine($"Test", LoggerType.Info);
             bytes.RemoveRange(54, bytes.Count - 54);
             // Append dictionary of entries
             foreach (var key in dict.Keys)


### PR DESCRIPTION
With this addition, if text.json contains a language key it will write into the according folder.

For example : 

Language : "FRA"

We will write in FRA instead of INT. 
If the key is absent, INT is selected as default, which is today's behavior. 

I only pushed the modificatiosn to the sources files. 